### PR TITLE
make `npm test` run linter as well

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,8 +4,10 @@
   "description": "This is a Node JS client for communicating with the full GoneBusy API",
   "main": "./lib/index.js",
   "scripts": {
-    "test": "mocha",
-    "lint": "eslint ."
+    "lint": "eslint .",
+    "lint:fix": "npm run lint -- --fix",
+    "test": "npm run lint && npm run test:unit",
+    "test:unit": "mocha"
   },
   "keywords": [],
   "author": "alex@gonebusy.com",


### PR DESCRIPTION
@Blaze34 Note that we're now baking in lint with running test, so that one doesn't have to remember to run lint + test as well as CI can now catch linter issues as well.